### PR TITLE
code generator issues

### DIFF
--- a/Sources/GraphQLSchemaCodeGen/Generator+Generate.swift
+++ b/Sources/GraphQLSchemaCodeGen/Generator+Generate.swift
@@ -85,21 +85,32 @@ extension Generator {
     }
 
     func printObjectTypes() throws {
-        guard !data.objects.isEmpty || !data.inputs.isEmpty else { return }
+        guard !data.objects.isEmpty || !data.inputs.isEmpty || !data.enums.isEmpty
+            || !data.interfaces.isEmpty || !data.unions.isEmpty
+        else { return }
         println()
         mark("Types")
         try scoped("extension \(data.schemaName)", scope: .curly) {
             try looped(data.objects) { object in
-                let objectInterfaces = object.interfaces.map { $0.name.value } + ["Codable"]
+                // Build conformance list: union protocols + interfaces + Codable
+                var conformances: [String] = []
+                for (unionName, members) in data.unionMembers {
+                    if members.contains(object.name.value) {
+                        conformances.append(unionName.escapedIfKeyword)
+                    }
+                }
+                conformances += object.interfaces.map { $0.name.value.escapedIfKeyword }
+                conformances.append("Codable")
+
                 try scoped(
-                    "struct \(object.name.value): \(objectInterfaces.joined(separator: ", "))",
+                    "struct \(object.name.value.escapedIfKeyword): \(conformances.joined(separator: ", "))",
                     scope: .curly
                 ) {
-                    let basicFields = object.basicFields(options: options)
-                    let computedFields = object.computedFields(options: options)
+                    let basicFields = object.basicFields(effectiveComputed: data.effectiveComputedFields)
+                    let computedFields = object.computedFields(effectiveComputed: data.effectiveComputedFields)
 
                     for field in basicFields {
-                        try println("let \(field.name.value): \(swiftTypeName(field.type))")
+                        try println("let \(field.name.value.escapedIfKeyword): \(swiftTypeName(field.type))")
                     }
 
                     if !computedFields.isEmpty {
@@ -113,7 +124,7 @@ extension Generator {
                                 ) {
                                     for argument in field.arguments {
                                         try println(
-                                            "let \(argument.name.value): \(swiftTypeName(argument.type))"
+                                            "let \(argument.name.value.escapedIfKeyword): \(swiftTypeName(argument.type))"
                                         )
                                     }
                                 }
@@ -121,11 +132,11 @@ extension Generator {
                             }
                             let argumentName = field.arguments.isEmpty ? "No" : field.name.value.capitalizeFirst
                             try scoped(
-                                "func _\(field.name.value)<ContextType>(context: ContextType, args: \(argumentName)Arguments) async throws -> \(swiftTypeName(field.type))",
+                                "func _\(field.name.value.escapedIfKeyword)<ContextType>(context: ContextType, args: \(argumentName)Arguments) async throws -> \(swiftTypeName(field.type))",
                                 scope: .curly
                             ) {
                                 scoped(
-                                    "guard let resolver = self as? any \(data.schemaName).\(object.name.value).Resolver<ContextType> else",
+                                    "guard let resolver = self as? any \(data.schemaName).\(object.name.value.escapedIfKeyword).Resolver<ContextType> else",
                                     scope: .curly
                                 ) {
                                     printThrowError(
@@ -133,7 +144,7 @@ extension Generator {
                                 }
                                 println()
                                 println(
-                                    "return try await resolver.\(field.name.value)(context: context, args: args)"
+                                    "return try await resolver.\(field.name.value.escapedIfKeyword)(context: context, args: args)"
                                 )
                             }
                         }
@@ -146,7 +157,7 @@ extension Generator {
                             for field in computedFields {
                                 let argumentName = field.arguments.isEmpty ? "No" : field.name.value.capitalizeFirst
                                 try println(
-                                    "func \(field.name.value)(context: ContextType, args: \(argumentName)Arguments) async throws -> \(swiftTypeName(field.type))"
+                                    "func \(field.name.value.escapedIfKeyword)(context: ContextType, args: \(argumentName)Arguments) async throws -> \(swiftTypeName(field.type))"
                                 )
                             }
                         }
@@ -158,7 +169,7 @@ extension Generator {
                             for field in key.fields {
                                 let objectField = try object.field(named: field)
                                 try println(
-                                    "let \(objectField.name.value): \(swiftTypeName(objectField.type))"
+                                    "let \(objectField.name.value.escapedIfKeyword): \(swiftTypeName(objectField.type))"
                                 )
                             }
                         }
@@ -168,9 +179,10 @@ extension Generator {
             if !data.inputs.isEmpty {
                 println()
                 try looped(data.inputs) { object in
-                    try scoped("struct \(object.name.value): Codable", scope: .curly) {
+                    let keyword = data.classInputTypes.contains(object.name.value) ? "class" : "struct"
+                    try scoped("\(keyword) \(object.name.value.escapedIfKeyword): Codable", scope: .curly) {
                         for field in object.fields {
-                            try println("let \(field.name.value): \(swiftTypeName(field.type))")
+                            try println("let \(field.name.value.escapedIfKeyword): \(swiftTypeName(field.type))")
                         }
                     }
                 }
@@ -178,10 +190,10 @@ extension Generator {
             if !data.enums.isEmpty {
                 println()
                 looped(data.enums) { object in
-                    scoped("enum \(object.name.value): String, Codable", scope: .curly) {
+                    scoped("enum \(object.name.value.escapedIfKeyword): String, Codable", scope: .curly) {
                         for value in object.values {
                             println(
-                                "case \(value.name.value.lowercased()) = \"\(value.name.value)\"")
+                                "case \(value.name.value.lowercased().escapedIfKeyword) = \"\(value.name.value)\"")
                         }
                     }
                 }
@@ -189,11 +201,18 @@ extension Generator {
             if !data.interfaces.isEmpty {
                 println()
                 try looped(data.interfaces) { interface in
-                    try scoped("protocol \(interface.name.value)", scope: .curly) {
+                    try scoped("protocol \(interface.name.value.escapedIfKeyword)", scope: .curly) {
                         for field in interface.fields {
                             try println(
-                                "var \(field.name.value): \(swiftTypeName(field.type)) { get }")
+                                "var \(field.name.value.escapedIfKeyword): \(swiftTypeName(field.type)) { get }")
                         }
+                    }
+                }
+            }
+            if !data.unions.isEmpty {
+                println()
+                looped(data.unions) { union in
+                    scoped("protocol \(union.name.value.escapedIfKeyword): Sendable", scope: .curly) {
                     }
                 }
             }
@@ -203,13 +222,14 @@ extension Generator {
     func printObjectResolverDefaultImplementation() throws {
         guard options.generateDefaultImplementation else { return }
         for object in data.objects {
-            let computedFields = object.fields.filter { !$0.arguments.isEmpty }
+            let computedFields = object.computedFields(effectiveComputed: data.effectiveComputedFields)
             guard !computedFields.isEmpty else { continue }
             println()
-            try scoped("extension \(data.schemaName).\(object.name.value).Resolver", scope: .curly) {
+            try scoped("extension \(data.schemaName).\(object.name.value.escapedIfKeyword).Resolver", scope: .curly) {
                 try looped(computedFields) { field in
+                    let argumentName = field.arguments.isEmpty ? "No" : "\(data.schemaName).\(object.name.value.escapedIfKeyword).\(field.name.value.capitalizeFirst)"
                     try scoped(
-                        "func \(field.name.value)(context: ContextType, args: \(data.schemaName).\(object.name.value).\(field.name.value.capitalizeFirst)Arguments) async throws -> \(swiftTypeName(field.type, namespace: data.schemaName))",
+                        "func \(field.name.value.escapedIfKeyword)(context: ContextType, args: \(argumentName)Arguments) async throws -> \(swiftTypeName(field.type, namespace: data.schemaName))",
                         scope: .curly
                     ) {
                         printThrowError(
@@ -229,7 +249,7 @@ extension Generator {
                     "struct \(field.name.value.capitalizeFirst)Arguments: Codable", scope: .curly
                 ) {
                     for argument in field.arguments {
-                        try println("let \(argument.name.value): \(swiftTypeName(argument.type))")
+                        try println("let \(argument.name.value.escapedIfKeyword): \(swiftTypeName(argument.type))")
                     }
                 }
             }
@@ -245,18 +265,18 @@ extension Generator {
                 println()
                 for field in (data.queryFields + data.mutationFields) {
                     try println(
-                        "func \(field.name.value)(context: ContextType, args: \(field.name.value.capitalizeFirst)Arguments) async throws -> \(swiftTypeName(field.type))"
+                        "func \(field.name.value.escapedIfKeyword)(context: ContextType, args: \(field.name.value.capitalizeFirst)Arguments) async throws -> \(swiftTypeName(field.type))"
                     )
                 }
                 for field in data.subscriptionFields {
                     try println(
-                        "func \(field.name.value)(context: ContextType, args: \(field.name.value.capitalizeFirst)Arguments) async throws -> EventStream<\(swiftTypeName(field.type))>"
+                        "func \(field.name.value.escapedIfKeyword)(context: ContextType, args: \(field.name.value.capitalizeFirst)Arguments) async throws -> EventStream<\(swiftTypeName(field.type))>"
                     )
                 }
                 for (object, keys) in data.objectsWithFederationKeys {
                     for key in keys {
                         println(
-                            "func \(object.name.value.lowercased())(context: ContextType, key: \(object.name.value).\(key.name)) async throws -> \(object.name.value)?"
+                            "func \(object.name.value.lowercased().escapedIfKeyword)(context: ContextType, key: \(object.name.value.escapedIfKeyword).\(key.name)) async throws -> \(object.name.value.escapedIfKeyword)?"
                         )
                     }
                 }
@@ -271,7 +291,7 @@ extension Generator {
         try scoped("extension \(data.schemaName).\(data.resolverName)", scope: .curly) {
             try looped(data.queryFields) { field in
                 try scoped(
-                    "func \(field.name.value)(context: ContextType, args: \(data.schemaName).\(field.name.value.capitalizeFirst)Arguments) async throws -> \(swiftTypeName(field.type, namespace: data.schemaName))",
+                    "func \(field.name.value.escapedIfKeyword)(context: ContextType, args: \(data.schemaName).\(field.name.value.capitalizeFirst)Arguments) async throws -> \(swiftTypeName(field.type, namespace: data.schemaName))",
                     scope: .curly
                 ) {
                     printThrowError("Resolver for query.\(field.name.value) is unimplemented.")
@@ -282,7 +302,7 @@ extension Generator {
             }
             try looped(data.mutationFields) { field in
                 try scoped(
-                    "func \(field.name.value)(context: ContextType, args: \(data.schemaName).\(field.name.value.capitalizeFirst)Arguments) async throws -> \(swiftTypeName(field.type, namespace: data.schemaName))",
+                    "func \(field.name.value.escapedIfKeyword)(context: ContextType, args: \(data.schemaName).\(field.name.value.capitalizeFirst)Arguments) async throws -> \(swiftTypeName(field.type, namespace: data.schemaName))",
                     scope: .curly
                 ) {
                     printThrowError("Resolver for mutation.\(field.name.value) is unimplemented.")
@@ -293,7 +313,7 @@ extension Generator {
             }
             try looped(data.subscriptionFields) { field in
                 try scoped(
-                    "func \(field.name.value)(context: ContextType, args: \(data.schemaName).\(field.name.value.capitalizeFirst)Arguments) async throws -> EventStream<\(swiftTypeName(field.type, namespace: data.schemaName))>",
+                    "func \(field.name.value.escapedIfKeyword)(context: ContextType, args: \(data.schemaName).\(field.name.value.capitalizeFirst)Arguments) async throws -> EventStream<\(swiftTypeName(field.type, namespace: data.schemaName))>",
                     scope: .curly
                 ) {
                     printThrowError(
@@ -306,7 +326,7 @@ extension Generator {
             looped(data.objectsWithFederationKeys) { (object, keys) in
                 for key in keys {
                     scoped(
-                        "func \(object.name.value.lowercased())(context: ContextType, key: \(data.schemaName).\(object.name.value).\(key.name)) async throws -> \(data.schemaName).\(object.name.value)?",
+                        "func \(object.name.value.lowercased().escapedIfKeyword)(context: ContextType, key: \(data.schemaName).\(object.name.value.escapedIfKeyword).\(key.name)) async throws -> \(data.schemaName).\(object.name.value.escapedIfKeyword)?",
                         scope: .curly
                     ) {
                         printThrowError(
@@ -343,7 +363,7 @@ extension Generator {
     func printSchemaBuilderTypes() throws {
         try scoped(".add", scope: .curly) {
             for scalar in data.scalars {
-                println("Scalar(\(scalar.name.value).self, as: \"\(scalar.name.value)\")")
+                println("Scalar(\(scalar.name.value.escapedIfKeyword).self, as: \"\(scalar.name.value)\")")
                 if let description = scalar.description?.value {
                     indent()
                     println(".description(\"\(description)\")")
@@ -351,66 +371,74 @@ extension Generator {
                 }
             }
             for object in data.objects {
-                let objectInterfaces = object.interfaces.map { "\($0.name.value).self" }
+                let objectInterfaces = object.interfaces.map { "\($0.name.value.escapedIfKeyword).self" }
                 let typeDeclaration: String
                 if objectInterfaces.isEmpty {
                     typeDeclaration =
-                        "Type(\(object.name.value).self, as: \"\(object.name.value)\")"
+                        "Type(\(object.name.value.escapedIfKeyword).self, as: \"\(object.name.value)\")"
                 } else {
                     typeDeclaration =
-                        "Type(\(object.name.value).self, as: \"\(object.name.value)\", interfaces: [\(objectInterfaces.joined(separator: ", "))])"
+                        "Type(\(object.name.value.escapedIfKeyword).self, as: \"\(object.name.value)\", interfaces: [\(objectInterfaces.joined(separator: ", "))])"
                 }
 
+                let effectiveOverrides = data.effectiveComputedFields[object.name.value, default: []]
                 scoped(typeDeclaration, scope: .curly) {
                     for field in object.fields {
-                        if field.arguments.isEmpty {
-                            if options.computedFields[object.name.value, default: []].contains(where: { $0 == field.name.value }) {
-                                println("Field(\"\(field.name.value)\", at: \(object.name.value)._\(field.name.value))")
+                        let isComputed = !field.arguments.isEmpty || effectiveOverrides.contains(field.name.value)
+                        if isComputed {
+                            if field.arguments.isEmpty {
+                                println("Field(\"\(field.name.value)\", at: \(object.name.value.escapedIfKeyword)._\(field.name.value.escapedIfKeyword))")
                             } else {
-                                println("Field(\"\(field.name.value)\", at: \\.\(field.name.value))")
-                            }
-                        } else {
-                            scoped(
-                                "Field(\"\(field.name.value)\", at: \(object.name.value)._\(field.name.value))",
-                                scope: .curly
-                            ) {
-                                for argument in field.arguments {
-                                    println(
-                                        "Argument(\"\(argument.name.value)\", at: \\.\(argument.name.value))"
-                                    )
+                                scoped(
+                                    "Field(\"\(field.name.value)\", at: \(object.name.value.escapedIfKeyword)._\(field.name.value.escapedIfKeyword))",
+                                    scope: .curly
+                                ) {
+                                    for argument in field.arguments {
+                                        println(
+                                            "Argument(\"\(argument.name.value)\", at: \\.\(argument.name.value.escapedIfKeyword))"
+                                        )
+                                    }
                                 }
                             }
+                        } else {
+                            println("Field(\"\(field.name.value)\", at: \\.\(field.name.value.escapedIfKeyword))")
                         }
                     }
                 }
                 for keys in try object.federationKeys() {
-                    scoped(".key(at: Resolver.\(object.name.value.lowercased()))", scope: .curly) {
+                    scoped(".key(at: Resolver.\(object.name.value.lowercased().escapedIfKeyword))", scope: .curly) {
                         for field in keys.fields {
-                            println("Argument(\"\(field)\", at: \\.\(field))")
+                            println("Argument(\"\(field)\", at: \\.\(field.escapedIfKeyword))")
                         }
                     }
                 }
             }
+            for union in data.unions {
+                let memberTypes = data.unionMembers[union.name.value, default: []]
+                    .map { "\($0.escapedIfKeyword).self" }
+                    .joined(separator: ", ")
+                println("Union(\(union.name.value.escapedIfKeyword).self, members: \(memberTypes))")
+            }
             for input in data.inputs {
                 scoped(
-                    "Input(\(input.name.value).self, as: \"\(input.name.value)\")", scope: .curly
+                    "Input(\(input.name.value.escapedIfKeyword).self, as: \"\(input.name.value)\")", scope: .curly
                 ) {
                     for field in input.fields {
-                        println("InputField(\"\(field.name.value)\", at: \\.\(field.name.value))")
+                        println("InputField(\"\(field.name.value)\", at: \\.\(field.name.value.escapedIfKeyword))")
                     }
                 }
             }
             for object in data.enums {
-                scoped("Enum(\(object.name.value).self)", scope: .curly) {
+                scoped("Enum(\(object.name.value.escapedIfKeyword).self)", scope: .curly) {
                     for value in object.values {
-                        println("Value(.\(value.name.value.lowercased()))")
+                        println("Value(.\(value.name.value.lowercased().escapedIfKeyword))")
                     }
                 }
             }
             for interface in data.interfaces {
-                scoped("Interface(\(interface.name.value).self)", scope: .curly) {
+                scoped("Interface(\(interface.name.value.escapedIfKeyword).self)", scope: .curly) {
                     for field in interface.fields {
-                        println("Field(\"\(field.name.value)\", at: \\.\(field.name.value))")
+                        println("Field(\"\(field.name.value)\", at: \\.\(field.name.value.escapedIfKeyword))")
                     }
                 }
             }
@@ -422,12 +450,12 @@ extension Generator {
         scoped(".addQuery", scope: .curly) {
             for field in data.queryFields {
                 scoped(
-                    "Field(\"\(field.name.value)\", at: Resolver.\(field.name.value))",
+                    "Field(\"\(field.name.value)\", at: Resolver.\(field.name.value.escapedIfKeyword))",
                     scope: .curly
                 ) {
                     for argument in field.arguments {
                         println(
-                            "Argument(\"\(argument.name.value)\", at: \\.\(argument.name.value))")
+                            "Argument(\"\(argument.name.value)\", at: \\.\(argument.name.value.escapedIfKeyword))")
                     }
                 }
             }
@@ -439,12 +467,12 @@ extension Generator {
         scoped(".addMutation", scope: .curly) {
             for field in data.mutationFields {
                 scoped(
-                    "Field(\"\(field.name.value)\", at: Resolver.\(field.name.value))",
+                    "Field(\"\(field.name.value)\", at: Resolver.\(field.name.value.escapedIfKeyword))",
                     scope: .curly
                 ) {
                     for argument in field.arguments {
                         println(
-                            "Argument(\"\(argument.name.value)\", at: \\.\(argument.name.value))")
+                            "Argument(\"\(argument.name.value)\", at: \\.\(argument.name.value.escapedIfKeyword))")
                     }
                 }
             }
@@ -456,12 +484,12 @@ extension Generator {
         try scoped(".addSubscription", scope: .curly) {
             for field in data.subscriptionFields {
                 try scoped(
-                    "SubscriptionField(\"\(field.name.value)\", as: \(swiftTypeName(field.type)).self, atSub: Resolver.\(field.name.value))",
+                    "SubscriptionField(\"\(field.name.value)\", as: \(swiftTypeName(field.type)).self, atSub: Resolver.\(field.name.value.escapedIfKeyword))",
                     scope: .curly
                 ) {
                     for argument in field.arguments {
                         println(
-                            "Argument(\"\(argument.name.value)\", at: \\.\(argument.name.value))")
+                            "Argument(\"\(argument.name.value)\", at: \\.\(argument.name.value.escapedIfKeyword))")
                     }
                 }
             }

--- a/Sources/GraphQLSchemaCodeGen/Generator+GraphQL.swift
+++ b/Sources/GraphQLSchemaCodeGen/Generator+GraphQL.swift
@@ -9,10 +9,24 @@ struct GeneratorData {
     let enums: [EnumTypeDefinition]
     let scalars: [ScalarTypeDefinition]
     let interfaces: [InterfaceTypeDefinition]
+    let unions: [UnionTypeDefinition]
     let queryFields: [FieldDefinition]
     let mutationFields: [FieldDefinition]
     let subscriptionFields: [FieldDefinition]
     let objectsWithFederationKeys: [(object: ObjectTypeDefinition, keys: [(name: String, fields: [String])])]
+
+    /// Merged computed fields map: user overrides + auto-detected (union-typed fields, cycle-breaking).
+    /// Key = object type name, Value = set of field names that should be computed.
+    let effectiveComputedFields: [String: Set<String>]
+
+    /// Map from union name to its member type names.
+    let unionMembers: [String: [String]]
+
+    /// Set of all union type names for quick lookup.
+    let unionTypeNames: Set<String>
+
+    /// Input types that must be emitted as `class` instead of `struct` to break cycles.
+    let classInputTypes: Set<String>
 
     init(options: GeneratorOptions, schemas: [String]) throws {
         self.schemaName = options.namespace + "Schema"
@@ -78,6 +92,7 @@ struct GeneratorData {
         self.enums = definitions.enums
         self.scalars = definitions.scalars
         self.interfaces = definitions.interfaces
+        self.unions = definitions.unions
 
         self.queryFields = definitions.objects(named: queryObjectName).flatMap { $0.fields }
         self.mutationFields = definitions.objects(named: mutationObjectName).flatMap { $0.fields }
@@ -87,6 +102,210 @@ struct GeneratorData {
         self.objectsWithFederationKeys = try definitions.objects
             .map { try ($0, $0.federationKeys()) }
             .filter { !$0.keys.isEmpty }
+
+        // Build union lookup tables
+        var unionMembers: [String: [String]] = [:]
+        var unionTypeNames: Set<String> = []
+        for union in self.unions {
+            let memberNames = union.types.map { $0.name.value }
+            unionMembers[union.name.value] = memberNames
+            unionTypeNames.insert(union.name.value)
+        }
+        self.unionMembers = unionMembers
+        self.unionTypeNames = unionTypeNames
+
+        // Build effective computed fields: start with user overrides
+        var effective: [String: Set<String>] = [:]
+        for (objectName, fields) in options.computedFields {
+            effective[objectName] = Set(fields)
+        }
+
+        // Auto-promote union-typed fields to computed (can't be stored as protocol existentials)
+        for object in self.objects {
+            for field in object.fields {
+                let referencedType = Self.namedTypeName(field.type)
+                if let typeName = referencedType, unionTypeNames.contains(typeName) {
+                    effective[object.name.value, default: []].insert(field.name.value)
+                }
+            }
+        }
+
+        // Detect cycles in object types and auto-break them
+        let objectTypeNames = Set(self.objects.map { $0.name.value })
+        let cycleBreakers = Self.detectCycleBreakingFields(
+            types: self.objects.map { ($0.name.value, $0.fields) },
+            knownTypeNames: objectTypeNames,
+            existingComputed: effective
+        )
+        for (typeName, fieldName) in cycleBreakers {
+            effective[typeName, default: []].insert(fieldName)
+            fputs(
+                "warning: Auto-promoting \(typeName).\(fieldName) to computed field to break type cycle\n",
+                stderr
+            )
+        }
+
+        self.effectiveComputedFields = effective
+
+        // Detect cycles in input types — these use `class` instead of `struct`
+        let inputTypeNames = Set(self.inputs.map { $0.name.value })
+        let inputCycleTypes = Self.detectCycleBreakingTypes(
+            types: self.inputs.map { ($0.name.value, $0.fields) },
+            knownTypeNames: inputTypeNames
+        )
+        self.classInputTypes = inputCycleTypes
+        for typeName in inputCycleTypes {
+            fputs(
+                "warning: Emitting input type \(typeName) as class to break type cycle\n",
+                stderr
+            )
+        }
+    }
+
+    /// Extracts the named type from a (potentially wrapped) GraphQL type, ignoring lists.
+    /// Returns nil for list types since arrays break cycles naturally.
+    static func namedTypeName(_ type: Type) -> String? {
+        switch type {
+        case let named as NamedType:
+            return named.name.value
+        case let nonNull as NonNullType:
+            return namedTypeName(nonNull.type)
+        case is ListType:
+            // Arrays store on heap — no infinite-size issue
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    /// Detect fields that need to become computed to break cycles in object types.
+    /// Returns pairs of (typeName, fieldName) to promote.
+    static func detectCycleBreakingFields(
+        types: [(name: String, fields: [FieldDefinition])],
+        knownTypeNames: Set<String>,
+        existingComputed: [String: Set<String>]
+    ) -> [(String, String)] {
+        // Build adjacency: type -> [(referencedType, fieldName, isOptional)]
+        var adjacency: [String: [(target: String, field: String, optional: Bool)]] = [:]
+        for (typeName, fields) in types {
+            for field in fields {
+                // Skip fields already marked as computed
+                if existingComputed[typeName]?.contains(field.name.value) == true {
+                    continue
+                }
+                // Skip fields with arguments (already computed)
+                if !field.arguments.isEmpty {
+                    continue
+                }
+                if let referencedType = namedTypeName(field.type),
+                   knownTypeNames.contains(referencedType)
+                {
+                    let isOptional = !(field.type is NonNullType)
+                    adjacency[typeName, default: []].append(
+                        (target: referencedType, field: field.name.value, optional: isOptional)
+                    )
+                }
+            }
+        }
+
+        var result: [(String, String)] = []
+        var visited: Set<String> = []
+        var inStack: Set<String> = []
+        var removedEdges: Set<String> = [] // "TypeName.fieldName" keys for removed edges
+
+        func edgeKey(_ typeName: String, _ fieldName: String) -> String {
+            "\(typeName).\(fieldName)"
+        }
+
+        func dfs(_ node: String, path: [(type: String, field: String, optional: Bool)]) {
+            if inStack.contains(node) {
+                // Found cycle — find the back edge in the path and break it
+                guard let cycleStart = path.firstIndex(where: { $0.type == node }) else { return }
+                let cycle = Array(path[cycleStart...])
+
+                // Prefer breaking at an optional field
+                let breakIdx: Int
+                if let optIdx = cycle.firstIndex(where: { $0.optional }) {
+                    breakIdx = optIdx
+                } else {
+                    breakIdx = cycle.count - 1
+                }
+
+                let edge = cycle[breakIdx]
+                let key = edgeKey(edge.type, edge.field)
+                if !removedEdges.contains(key) {
+                    removedEdges.insert(key)
+                    result.append((edge.type, edge.field))
+                }
+                return
+            }
+
+            if visited.contains(node) { return }
+            visited.insert(node)
+            inStack.insert(node)
+
+            for edge in adjacency[node, default: []] {
+                let key = edgeKey(node, edge.field)
+                if removedEdges.contains(key) { continue }
+                dfs(edge.target, path: path + [(type: node, field: edge.field, optional: edge.optional)])
+            }
+
+            inStack.remove(node)
+        }
+
+        for (typeName, _) in types {
+            dfs(typeName, path: [])
+        }
+
+        return result
+    }
+
+    /// Detect input types that need to be emitted as `class` to break cycles.
+    /// Returns a set of type names that should use `class`.
+    static func detectCycleBreakingTypes(
+        types: [(name: String, fields: [InputValueDefinition])],
+        knownTypeNames: Set<String>
+    ) -> Set<String> {
+        // Build adjacency for input types
+        var adjacency: [String: [String]] = [:]
+        for (typeName, fields) in types {
+            for field in fields {
+                if let referencedType = namedTypeName(field.type),
+                   knownTypeNames.contains(referencedType)
+                {
+                    adjacency[typeName, default: []].append(referencedType)
+                }
+            }
+        }
+
+        // Find all types involved in cycles using DFS
+        var visited: Set<String> = []
+        var inStack: Set<String> = []
+        var cycleTypes: Set<String> = []
+
+        func dfs(_ node: String, path: [String]) {
+            if inStack.contains(node) {
+                // Found cycle — mark the node that completes the cycle as class
+                // (breaking the cycle at one point is sufficient)
+                cycleTypes.insert(node)
+                return
+            }
+            if visited.contains(node) { return }
+            visited.insert(node)
+            inStack.insert(node)
+
+            for neighbor in adjacency[node, default: []] {
+                dfs(neighbor, path: path + [node])
+            }
+
+            inStack.remove(node)
+        }
+
+        for (typeName, _) in types {
+            dfs(typeName, path: [])
+        }
+
+        return cycleTypes
     }
 }
 
@@ -151,6 +370,16 @@ extension [any Definition] {
         }
     }
 
+    var unions: [UnionTypeDefinition] {
+        self.compactMap {
+            if let union = $0 as? UnionTypeDefinition { return union }
+            if let unionExtension = $0 as? UnionExtensionDefinition {
+                return unionExtension.definition
+            }
+            return nil
+        }
+    }
+
     func objects(named: String) -> [ObjectTypeDefinition] {
         objects.filter { $0.name.value == named }
     }
@@ -164,8 +393,22 @@ extension ObjectTypeDefinition {
         }
     }
 
+    func basicFields(effectiveComputed: [String: Set<String>]) -> [FieldDefinition] {
+        let overrides = effectiveComputed[name.value, default: []]
+        return fields.filter {
+            $0.arguments.isEmpty && !overrides.contains($0.name.value)
+        }
+    }
+
     func computedFields(options: GeneratorOptions) -> [FieldDefinition] {
         let overrides = options.computedFields[name.value, default: []]
+        return fields.filter {
+            !$0.arguments.isEmpty || overrides.contains($0.name.value)
+        }
+    }
+
+    func computedFields(effectiveComputed: [String: Set<String>]) -> [FieldDefinition] {
+        let overrides = effectiveComputed[name.value, default: []]
         return fields.filter {
             !$0.arguments.isEmpty || overrides.contains($0.name.value)
         }
@@ -224,10 +467,12 @@ extension Generator {
     {
         switch type {
         case let type as NamedType:
-            if nestedInNonNull {
-                return swiftTypeMapping(type.name.value, namespace: namespace)
+            let name = swiftTypeMapping(type.name.value, namespace: namespace)
+            let isUnion = data.unionTypeNames.contains(type.name.value)
+            if isUnion {
+                return nestedInNonNull ? "any \(name)" : "(any \(name))?"
             } else {
-                return "\(swiftTypeMapping(type.name.value, namespace: namespace))?"
+                return nestedInNonNull ? name : "\(name)?"
             }
         case let type as NonNullType:
             return try swiftTypeName(type.type, namespace: namespace, nestedInNonNull: true)

--- a/Sources/GraphQLSchemaCodeGen/String+Helpers.swift
+++ b/Sources/GraphQLSchemaCodeGen/String+Helpers.swift
@@ -4,4 +4,28 @@ extension String {
     var capitalizeFirst: String {
         prefix(1).uppercased() + dropFirst()
     }
+
+    // Swift reserved keywords that require backtick escaping when used as identifiers.
+    // Reference: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Keywords-and-Punctuation
+    private static let swiftKeywords: Set<String> = [
+        // Declarations
+        "associatedtype", "class", "deinit", "enum", "extension", "fileprivate",
+        "func", "import", "init", "inout", "internal", "let", "open", "operator",
+        "private", "precedencegroup", "protocol", "public", "rethrows", "static",
+        "struct", "subscript", "typealias", "var",
+        // Statements
+        "break", "case", "catch", "continue", "default", "defer", "do", "else",
+        "fallthrough", "for", "guard", "if", "in", "repeat", "return", "switch",
+        "throw", "where", "while",
+        // Expressions and types
+        "Any", "as", "false", "is", "nil", "self", "Self", "super", "throws",
+        "true", "try",
+    ]
+
+    /// Returns the string wrapped in backticks if it is a Swift reserved keyword.
+    /// Backtick-escaped identifiers are Codable-safe: Swift strips backticks from
+    /// the actual identifier name, so synthesized CodingKeys use the original key.
+    var escapedIfKeyword: String {
+        Self.swiftKeywords.contains(self) ? "`\(self)`" : self
+    }
 }

--- a/Tests/GraphQLSchemaCodeGenTests/Generator.test.swift
+++ b/Tests/GraphQLSchemaCodeGenTests/Generator.test.swift
@@ -1016,4 +1016,588 @@ final class GeneratorTests: XCTestCase {
 
         XCTAssertNoDifference(generator.code, expected)
     }
+
+    // MARK: - Keyword Escaping Tests
+
+    func testKeywordEscapingObjectFields() throws {
+        let schema =
+            """
+            type Assignment {
+                id: ID!
+                operator: Person
+                default: Boolean
+                class: String
+            }
+
+            type Person {
+                id: ID!
+                name: String!
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printObjectTypes()
+
+        let expected =
+            """
+
+            // MARK: - Types
+            extension GeneratedSchema {
+              struct Assignment: Codable {
+                let id: ID
+                let `operator`: Person?
+                let `default`: Bool?
+                let `class`: String?
+              }
+
+              struct Person: Codable {
+                let id: ID
+                let name: String
+              }
+            }
+
+            """
+
+        XCTAssertNoDifference(expected, generator.code)
+    }
+
+    func testKeywordEscapingInputFields() throws {
+        let schema =
+            """
+            type Holder {
+                id: ID!
+            }
+
+            input FilterInput {
+                operator: String
+                where: String
+                in: [ID!]
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printObjectTypes()
+
+        let expected =
+            """
+
+            // MARK: - Types
+            extension GeneratedSchema {
+              struct Holder: Codable {
+                let id: ID
+              }
+
+              struct FilterInput: Codable {
+                let `operator`: String?
+                let `where`: String?
+                let `in`: [ID]
+              }
+            }
+
+            """
+
+        XCTAssertNoDifference(expected, generator.code)
+    }
+
+    func testKeywordEscapingEnumCases() throws {
+        let schema =
+            """
+            type Holder {
+                id: ID!
+            }
+
+            enum BooleanResult {
+                TRUE
+                FALSE
+                NIL
+                DEFAULT
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printObjectTypes()
+
+        let expected =
+            """
+
+            // MARK: - Types
+            extension GeneratedSchema {
+              struct Holder: Codable {
+                let id: ID
+              }
+
+              enum BooleanResult: String, Codable {
+                case `true` = "TRUE"
+                case `false` = "FALSE"
+                case `nil` = "NIL"
+                case `default` = "DEFAULT"
+              }
+            }
+
+            """
+
+        XCTAssertNoDifference(expected, generator.code)
+    }
+
+    func testKeywordEscapingResolverProtocol() throws {
+        let schema =
+            """
+            type Query {
+                default(in: ID!): String
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printResolverArguments()
+
+        let expected =
+            """
+
+            // MARK: - Resolver Arguments
+            extension GeneratedSchema {
+              struct DefaultArguments: Codable {
+                let `in`: ID
+              }
+            }
+
+            """
+
+        XCTAssertNoDifference(expected, generator.code)
+    }
+
+    func testKeywordEscapingSchemaBuilder() throws {
+        let schema =
+            """
+            type Assignment {
+                id: ID!
+                operator: String
+                default: Boolean
+            }
+
+            input FilterInput {
+                operator: String
+                where: String
+            }
+
+            enum BooleanResult {
+                TRUE
+                FALSE
+                DEFAULT
+            }
+
+            type Query {
+                assignment(id: ID!): Assignment
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printSchemaBuilder()
+
+        let expected =
+            """
+
+            // MARK: - Schema Builder
+            extension GeneratedSchema {
+              static func schema<Resolver>(coders: Coders = Coders()) throws -> Schema<Resolver, Resolver.ContextType> where Resolver: GeneratedResolver {
+                try SchemaBuilder(Resolver.self, Resolver.ContextType.self)
+                  .setCoders(to: coders)
+                  .setFederatedSDL(to: sdl)
+                  .add {
+                    Type(Assignment.self, as: "Assignment") {
+                      Field("id", at: \\.id)
+                      Field("operator", at: \\.`operator`)
+                      Field("default", at: \\.`default`)
+                    }
+                    Input(FilterInput.self, as: "FilterInput") {
+                      InputField("operator", at: \\.`operator`)
+                      InputField("where", at: \\.`where`)
+                    }
+                    Enum(BooleanResult.self) {
+                      Value(.`true`)
+                      Value(.`false`)
+                      Value(.`default`)
+                    }
+                  }
+                  .addQuery {
+                    Field("assignment", at: Resolver.assignment) {
+                      Argument("id", at: \\.id)
+                    }
+                  }
+                  .build()
+              }
+            }
+
+            """
+
+        XCTAssertNoDifference(expected, generator.code)
+    }
+
+    func testKeywordEscapingComputedField() throws {
+        let schema =
+            """
+            type Task {
+                id: ID!
+                operator(role: String!): Person
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printObjectTypes()
+
+        let expected =
+            """
+
+            // MARK: - Types
+            extension GeneratedSchema {
+              struct Task: Codable {
+                let id: ID
+
+                struct OperatorArguments: Codable {
+                  let role: String
+                }
+
+                func _`operator`<ContextType>(context: ContextType, args: OperatorArguments) async throws -> Person? {
+                  guard let resolver = self as? any GeneratedSchema.Task.Resolver<ContextType> else {
+                    throw GeneratedSchemaError(description: "Task.operator is unimplemented")
+                  }
+
+                  return try await resolver.`operator`(context: context, args: args)
+                }
+
+                protocol Resolver<ContextType> {
+                  associatedtype ContextType
+
+                  func `operator`(context: ContextType, args: OperatorArguments) async throws -> Person?
+                }
+              }
+            }
+
+            """
+
+        XCTAssertNoDifference(expected, generator.code)
+    }
+
+    // MARK: - Union Type Tests
+
+    func testUnionTypes() throws {
+        let schema =
+            """
+            type Dog {
+                name: String!
+                breed: String
+            }
+
+            type Cat {
+                name: String!
+                indoor: Boolean
+            }
+
+            union Pet = Dog | Cat
+
+            type Owner {
+                id: ID!
+                pet: Pet
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printObjectTypes()
+
+        let expected =
+            """
+
+            // MARK: - Types
+            extension GeneratedSchema {
+              struct Dog: Pet, Codable {
+                let name: String
+                let breed: String?
+              }
+
+              struct Cat: Pet, Codable {
+                let name: String
+                let indoor: Bool?
+              }
+
+              struct Owner: Codable {
+                let id: ID
+
+                func _pet<ContextType>(context: ContextType, args: NoArguments) async throws -> (any Pet)? {
+                  guard let resolver = self as? any GeneratedSchema.Owner.Resolver<ContextType> else {
+                    throw GeneratedSchemaError(description: "Owner.pet is unimplemented")
+                  }
+
+                  return try await resolver.pet(context: context, args: args)
+                }
+
+                protocol Resolver<ContextType> {
+                  associatedtype ContextType
+
+                  func pet(context: ContextType, args: NoArguments) async throws -> (any Pet)?
+                }
+              }
+
+              protocol Pet: Sendable {
+              }
+            }
+
+            """
+
+        XCTAssertNoDifference(expected, generator.code)
+    }
+
+    func testUnionSchemaBuilder() throws {
+        let schema =
+            """
+            type Dog {
+                name: String!
+                breed: String
+            }
+
+            type Cat {
+                name: String!
+                indoor: Boolean
+            }
+
+            union Pet = Dog | Cat
+
+            type Owner {
+                id: ID!
+                pet: Pet
+            }
+
+            type Query {
+                owner(id: ID!): Owner
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printSchemaBuilder()
+
+        let expected =
+            """
+
+            // MARK: - Schema Builder
+            extension GeneratedSchema {
+              static func schema<Resolver>(coders: Coders = Coders()) throws -> Schema<Resolver, Resolver.ContextType> where Resolver: GeneratedResolver {
+                try SchemaBuilder(Resolver.self, Resolver.ContextType.self)
+                  .setCoders(to: coders)
+                  .setFederatedSDL(to: sdl)
+                  .add {
+                    Type(Dog.self, as: "Dog") {
+                      Field("name", at: \\.name)
+                      Field("breed", at: \\.breed)
+                    }
+                    Type(Cat.self, as: "Cat") {
+                      Field("name", at: \\.name)
+                      Field("indoor", at: \\.indoor)
+                    }
+                    Type(Owner.self, as: "Owner") {
+                      Field("id", at: \\.id)
+                      Field("pet", at: Owner._pet)
+                    }
+                    Union(Pet.self, members: Dog.self, Cat.self)
+                  }
+                  .addQuery {
+                    Field("owner", at: Resolver.owner) {
+                      Argument("id", at: \\.id)
+                    }
+                  }
+                  .build()
+              }
+            }
+
+            """
+
+        XCTAssertNoDifference(expected, generator.code)
+    }
+
+    func testUnionResolverDefaultImplementation() throws {
+        let schema =
+            """
+            type Dog {
+                name: String!
+            }
+
+            type Cat {
+                name: String!
+            }
+
+            union Pet = Dog | Cat
+
+            type Owner {
+                id: ID!
+                pet: Pet
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printObjectResolverDefaultImplementation()
+
+        let expected =
+            """
+
+            extension GeneratedSchema.Owner.Resolver {
+              func pet(context: ContextType, args: NoArguments) async throws -> (any GeneratedSchema.Pet)? {
+                throw GeneratedSchemaError(description: "Owner.pet is unimplemented.")
+              }
+            }
+
+            """
+
+        XCTAssertNoDifference(expected, generator.code)
+    }
+
+    // MARK: - Circular Type Detection Tests
+
+    func testCircularTypeDetection() throws {
+        let schema =
+            """
+            type Vehicle {
+                id: ID!
+                name: String!
+                dispenser: Dispenser
+            }
+
+            type Dispenser {
+                id: ID!
+                status: String!
+                vehicle: Vehicle
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printObjectTypes()
+
+        // At least one field in the cycle should be promoted to computed
+        // The generated code should contain a Resolver protocol for the type that got the computed field
+        let code = generator.code
+
+        // Both types should be present as structs
+        XCTAssert(code.contains("struct Vehicle: Codable"), "Vehicle struct should be generated")
+        XCTAssert(code.contains("struct Dispenser: Codable"), "Dispenser struct should be generated")
+
+        // At least one field should be computed (has a Resolver protocol)
+        XCTAssert(
+            code.contains("protocol Resolver<ContextType>"),
+            "At least one type should have a Resolver protocol for cycle-breaking computed field"
+        )
+
+        // The computed field should use NoArguments (no GraphQL arguments)
+        XCTAssert(
+            code.contains("NoArguments"),
+            "Cycle-breaking computed field should use NoArguments"
+        )
+    }
+
+    func testSelfReferentialType() throws {
+        let schema =
+            """
+            type Node {
+                id: ID!
+                children: [Node!]!
+                parent: Node
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printObjectTypes()
+
+        let code = generator.code
+
+        // children is an array, so it doesn't create a cycle (arrays store on heap)
+        // parent is a direct reference, so it should be promoted to computed
+        XCTAssert(code.contains("struct Node: Codable"), "Node struct should be generated")
+        XCTAssert(code.contains("let id: ID"), "id should be a stored property")
+        XCTAssert(code.contains("let children: [Node]"), "children (array) should be stored")
+        XCTAssert(
+            code.contains("func _parent"),
+            "parent should be promoted to computed field to break self-reference"
+        )
+    }
+
+    func testCircularTypeSchemaBuilder() throws {
+        let schema =
+            """
+            type Vehicle {
+                id: ID!
+                name: String!
+                dispenser: Dispenser
+            }
+
+            type Dispenser {
+                id: ID!
+                status: String!
+                vehicle: Vehicle
+            }
+
+            type Query {
+                vehicle(id: ID!): Vehicle
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printSchemaBuilder()
+
+        let code = generator.code
+
+        // The cycle-breaking field should use function reference (Type._field) not keypath
+        let hasFunctionRef =
+            code.contains("Vehicle._dispenser") || code.contains("Dispenser._vehicle")
+        XCTAssert(
+            hasFunctionRef,
+            "Cycle-breaking field should use function reference in schema builder"
+        )
+    }
+
+    // MARK: - Recursive Input Type Tests
+
+    func testRecursiveInputTypes() throws {
+        let schema =
+            """
+            type Holder {
+                id: ID!
+            }
+
+            input VehicleEventInputs {
+                amendment: AmendmentInput
+                other: String
+            }
+
+            input AmendmentInput {
+                event: VehicleEventInputs
+                reason: String
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printObjectTypes()
+
+        let code = generator.code
+
+        // At least one input type should be emitted as class to break the cycle
+        XCTAssert(
+            code.contains("class VehicleEventInputs: Codable") || code.contains("class AmendmentInput: Codable"),
+            "At least one recursive input type should be emitted as class"
+        )
+
+        // The other can remain a struct
+        XCTAssert(
+            code.contains("struct VehicleEventInputs: Codable") || code.contains("struct AmendmentInput: Codable"),
+            "Non-cycle-breaking input type should remain a struct"
+        )
+    }
+
+    func testNonRecursiveInputsRemainStructs() throws {
+        let schema =
+            """
+            type Holder {
+                id: ID!
+            }
+
+            input CreateInput {
+                name: String!
+            }
+
+            input UpdateInput {
+                id: ID!
+                name: String
+            }
+            """
+        let generator = try Generator(schemas: [schema])
+        try generator.printObjectTypes()
+
+        let code = generator.code
+
+        // No cycles, so both should be structs
+        XCTAssert(code.contains("struct CreateInput: Codable"), "CreateInput should be a struct")
+        XCTAssert(code.contains("struct UpdateInput: Codable"), "UpdateInput should be a struct")
+        XCTAssertFalse(code.contains("class"), "No class should be generated for non-recursive inputs")
+    }
 }


### PR DESCRIPTION
- Fix generated Swift code being invalid when GraphQL field/argument/enum names collide with Swift reserved keywords (e.g. operator, default, in, true) by applying backtick escaping at all ~40 identifier emission sites
- Add support for GraphQL union types — generates Sendable protocols, adds conformances to member structs, registers Union() in the schema builder, and auto-promotes union-typed fields to computed (since protocol existentials can't be stored properties)
- Detect circular type references in output types (e.g. Vehicle.dispenser: Dispenser / Dispenser.vehicle: Vehicle) and automatically promote cycle-breaking fields to computed, reusing the existing computedFields machinery
- Detect circular type references in input types and emit class instead of struct for one type per cycle to break infinite-size struct issues